### PR TITLE
Fix timing issue

### DIFF
--- a/src/BotQueue.dcl
+++ b/src/BotQueue.dcl
@@ -5,13 +5,18 @@ import Bot
 
 :: BotQueue
 
-// Creates an empty BotQueue
+/**
+ * Creates an empty BotQueue
+ */
 newBotQueue :: BotQueue
 
-// Inserts a bot into the correct position in the queue
-// @param The Queue that the bot needs to be inserted into
-// @param The Bot that needs to be inserted
-insertBot :: BotQueue Bot -> BotQueue
+/**
+ * Inserts a bot into the correct position in the queue
+ * @param The Bot that needs to be inserted
+ * @param The Queue that the bot needs to be inserted into
+ * @result The new Queue
+ */
+insertBot :: Bot BotQueue -> BotQueue
 
 allBotsOnZero :: BotQueue -> ([Bot], BotQueue)
 

--- a/src/BotQueue.dcl
+++ b/src/BotQueue.dcl
@@ -20,7 +20,7 @@ insertBot :: Bot BotQueue -> BotQueue
 
 allBotsOnZero :: BotQueue -> ([Bot], BotQueue)
 
-decrementAll :: BotQueue -> BotQueue
+mapQueue :: ((Bot -> Bot) BotQueue -> BotQueue)
 
 runRequired :: BotQueue -> Bool
 

--- a/src/BotQueue.icl
+++ b/src/BotQueue.icl
@@ -10,10 +10,10 @@ import StdInt
 newBotQueue :: BotQueue
 newBotQueue = []
 
-insertBot :: BotQueue Bot -> BotQueue
-insertBot [] bot = [bot]
-insertBot [x:xs] bot
-| bot.interval >= x.interval = [x : insertBot xs bot]
+insertBot :: Bot BotQueue -> BotQueue
+insertBot bot [] = [bot]
+insertBot bot [x:xs]
+| bot.interval >= x.interval = [x : insertBot bot xs]
 | otherwise = [bot] ++ [x:xs]
 
 allBotsOnZero :: BotQueue -> ([Bot], BotQueue)

--- a/src/BotQueue.icl
+++ b/src/BotQueue.icl
@@ -21,8 +21,8 @@ allBotsOnZero :: BotQueue -> ([Bot], BotQueue)
 allBotsOnZero queue
 = splitWith (\b -> b.interval == 0) queue
 
-decrementAll :: BotQueue -> BotQueue
-decrementAll queue = map (\x -> {x & interval = x.interval - 1}) queue
+mapQueue :: ((Bot -> Bot) BotQueue -> BotQueue)
+mapQueue = map
 
 runRequired :: BotQueue -> Bool
 runRequired [] = False

--- a/src/Clone.icl
+++ b/src/Clone.icl
@@ -16,10 +16,12 @@ Start world
 
 loop :: Config BotQueue !*World -> ()
 loop config queue world
-# queue = decrementAll queue
 # (queue, world) = runRequiredBots config queue world
-# (_, world) = sleep (getWaitTime queue) world
+# queue = mapQueue (\b -> {b & interval = b.interval - time}) queue
+# (_, world) = sleep time world
 = loop config queue world
+where
+	time = getWaitTime queue
 
 runRequiredBots :: Config BotQueue !*World -> (!BotQueue, !*World)
 runRequiredBots config queue world


### PR DESCRIPTION
Most importantly, this fixes a timing issue: in `loop`, `decrementAll` would be called on every iteration and the sleep time would be set to `getWaitTime queue`, which meant that a 60s bot would wait 60s, 59s, 58s, etc. This is fixed by replacing `decrementAll` with `mapQueue` and mapping a decrement of the waiting time on the intervals of the bots. However, the `runRequiredBots` call in `loop` also takes up time, so if timing is critical it may be better to do timing by checking the current time rather than using `sleep`.

Additionally, I made several changes for documentation, moving parameters around on insertBot which allowed me to remove some lambda functions elsewhere.

I realise that this should not have been one PR but was working on several things at the same time. Feel free to reject the PR and make the fix for `loop` yourself.